### PR TITLE
Translation 8.2.9.0 (Russian)

### DIFF
--- a/src/OfficeToolPlus/Style/Languages/ru-ru.xaml
+++ b/src/OfficeToolPlus/Style/Languages/ru-ru.xaml
@@ -49,8 +49,8 @@
     <!-- What is &amp; means? '&amp;' stands for '&', so it is &Install now, users can press the hotkey (I) to execute the command when menu is opened. -->
     <!-- Learn more about hotkey and autorun.inf: https://en.wikipedia.org/wiki/Autorun.inf#:~:text=shell%5Cverb%3Dmenu%20text -->
     <!-- If you can't understand what is hotkey, remove '&amp;' when you are translating. -->
-    <sys:String x:Key="CD-ROM_InstallNow">&amp;Install now</sys:String>
-    <sys:String x:Key="CopyToClipboard">Copy to clipboard</sys:String>
+    <sys:String x:Key="CD-ROM_InstallNow">Установить сейчас</sys:String>
+    <sys:String x:Key="CopyToClipboard">Скопировать в буфер</sys:String>
 
     <!-- Greetings -->
     <!-- Showed when app started. -->
@@ -339,11 +339,11 @@
     <sys:String x:Key="ToolboxRepairVBS">Восстановление ассоциации VBS файла</sys:String>
     <sys:String x:Key="ToolboxRepairVBSDescription">Это восстановит ассоциацию файлов VBS и применимо к активации Office с запросом «Нет обработчика сценария для расширения файла ".vbs"».</sys:String>
     <sys:String x:Key="ToolboxRepairVariables">Восстановление системных переменных</sys:String>
-    <sys:String x:Key="ToolboxRepairVariablesDescription">This will reset your system variables to default values. Do not use it if you are unsure.&#x000A;&#x000A;After the repair is complete, you need to reboot your system for it to take effect.</sys:String>
-    <sys:String x:Key="ToolboxRepairWMI">Repair WMI component</sys:String>
-    <sys:String x:Key="ToolboxRepairWMIDescription">This will re-register the WMI component. Do not use it if you are unsure.&#x000A;&#x000A;After the repair is complete, you need to reboot your system for it to take effect.</sys:String>
+    <sys:String x:Key="ToolboxRepairVariablesDescription">Это сбросит системные переменные в начальное состояние. Не используйте, если не уверены.&#x000A;&#x000A;После завершения восстановления обязательно перезагрузите ПК, чтобы применить изменения.</sys:String>
+    <sys:String x:Key="ToolboxRepairWMI">Восстановить компонент WMI </sys:String>
+    <sys:String x:Key="ToolboxRepairWMIDescription">Это перерегистрирует компонент WMI. Не используйте, если не уверены.&#x000A;&#x000A;После завершения восстановления обязательно перезагрузите ПК, чтобы применить изменения.</sys:String>
     <sys:String x:Key="ToolboxRepairTemplates">Восстановление стандартного шаблона для Word</sys:String>
-    <sys:String x:Key="ToolboxRepairTemplatesDescription">This will rebuild Word's default template.</sys:String>
+    <sys:String x:Key="ToolboxRepairTemplatesDescription">Это пересоздаст стандартный шаблон для Word.</sys:String>
     <sys:String x:Key="ToolboxResetOfficeSettings">Восстановление исходных настроек Office</sys:String>
     <sys:String x:Key="ToolboxResetOfficeSettingsDescription">Это приведёт к сбросу настроек Office, включая настройки приложений, локальную историю файлов и недавние пути сохранения.&#x000A;Пожалуйста, перед продолжением закройте все приложения Office.</sys:String>
     <!-- Convert Document -->
@@ -453,7 +453,7 @@
     <sys:String x:Key="Task_CheckKMS">Тестирование KMS хоста(-ов).</sys:String>
     <sys:String x:Key="Task_CollectLog">Сбор установочных журналов Office.</sys:String>
     <sys:String x:Key="Task_RemoveOffice">Очистка от Office.</sys:String>
-    <sys:String x:Key="Task_RepairWMI">Repairing WMI, please wait.</sys:String>
+    <sys:String x:Key="Task_RepairWMI">Восстановление WMI, пожалуйста, подождите.</sys:String>
     <sys:String x:Key="Task_ConvertDocument">Конвертация документов.</sys:String>
     <!-- Example: Installing iSlide, please wait. -->
     <sys:String x:Key="Task_InstallingApp">Установка {0}, нужно подождать.</sys:String>
@@ -481,14 +481,14 @@
     <sys:String x:Key="InfoRestart">Вам необходимо перезапустить приложение для просмотра изменений.</sys:String>
     <sys:String x:Key="InfoUpdate">Вы используете последнюю версию Office Tool Plus.</sys:String>
     <sys:String x:Key="InfoNoConfigured">Изменения не обнаружены</sys:String>
-    <sys:String x:Key="InfoNoLanguagePackAddedForDownload">We have detected that you have not added a language. In most cases, we recommend that you add languages to avoid problems.</sys:String>
+    <sys:String x:Key="InfoNoLanguagePackAddedForDownload">Мы обнаружили, что вы не добавили язык. В большинтсве случаев мы рекомендуем добавить язык или несколько языков, чтобы избежать проблем в будущем.</sys:String>
     <sys:String x:Key="InfoAllExist">Скачивание не требуется, все файлы существуют.</sys:String>
     <sys:String x:Key="InfoFinishVerifying">Установочные файлы проверены, ошибки не найдены.</sys:String>
     <sys:String x:Key="InfoDownloading">Скачивание Office началось.</sys:String>
     <sys:String x:Key="InfoSetupExited">Работа Office Deployment Tool завершена нормально.</sys:String>
     <sys:String x:Key="InfoInstallationComplete">Установка завершена.</sys:String>
     <sys:String x:Key="InfoInstallationFailed">Установка окончилась провалом.</sys:String>
-    <sys:String x:Key="InfoNoOfficeDetectedForActivation">The Click-to-Run version of Office was not detected on this computer, the Office licenses could not be loaded.</sys:String>
+    <sys:String x:Key="InfoNoOfficeDetectedForActivation">Office с типом установки Click-to-Run ("Нажми и работай") не обнаружен на этом компьютере, лицензии Office не могут быть загружены.</sys:String>
 
     <!-- Success Message -->
     <sys:String x:Key="SuccessAddDownloadTask">Успешное добавление задачи скачивания</sys:String>

--- a/src/OfficeToolPlus/Style/Languages/ru-ru.xaml
+++ b/src/OfficeToolPlus/Style/Languages/ru-ru.xaml
@@ -49,7 +49,7 @@
     <!-- What is &amp; means? '&amp;' stands for '&', so it is &Install now, users can press the hotkey (I) to execute the command when menu is opened. -->
     <!-- Learn more about hotkey and autorun.inf: https://en.wikipedia.org/wiki/Autorun.inf#:~:text=shell%5Cverb%3Dmenu%20text -->
     <!-- If you can't understand what is hotkey, remove '&amp;' when you are translating. -->
-    <sys:String x:Key="CD-ROM_InstallNow">Установить сейчас (&amp;I)</sys:String>
+    <sys:String x:Key="CD-ROM_InstallNow">Установить сейчас</sys:String>
     <sys:String x:Key="CopyToClipboard">Скопировать в буфер</sys:String>
 
     <!-- Greetings -->

--- a/src/OfficeToolPlus/Style/Languages/ru-ru.xaml
+++ b/src/OfficeToolPlus/Style/Languages/ru-ru.xaml
@@ -49,7 +49,7 @@
     <!-- What is &amp; means? '&amp;' stands for '&', so it is &Install now, users can press the hotkey (I) to execute the command when menu is opened. -->
     <!-- Learn more about hotkey and autorun.inf: https://en.wikipedia.org/wiki/Autorun.inf#:~:text=shell%5Cverb%3Dmenu%20text -->
     <!-- If you can't understand what is hotkey, remove '&amp;' when you are translating. -->
-    <sys:String x:Key="CD-ROM_InstallNow">Установить сейчас</sys:String>
+    <sys:String x:Key="CD-ROM_InstallNow">Установить сейчас (&amp;I)</sys:String>
     <sys:String x:Key="CopyToClipboard">Скопировать в буфер</sys:String>
 
     <!-- Greetings -->


### PR DESCRIPTION
Hotkey can't by indicated, because translate the string without the hotkey letter. 