### PR TITLE
Update ko-kr.xaml

### DIFF
--- a/src/OfficeToolPlus/Dictionaries/ProductsName/ko-kr.xaml
+++ b/src/OfficeToolPlus/Dictionaries/ProductsName/ko-kr.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=System.RunTime"
                     xml:space="preserve">
@@ -76,6 +76,7 @@
     <sys:String x:Key="ProPlus2019Volume">Office Professional Plus 2019 - 볼륨 라이선스</sys:String>
     <sys:String x:Key="ProPlus2021Retail">Office Professional Plus 2021</sys:String>
     <sys:String x:Key="ProPlus2021Volume">Office LTSC Professional Plus 2021 - 볼륨 라이선스</sys:String>
+    <!-- If you are translating to LTR language, please remove '&#x200e;', otherwise keep it. -->
     <sys:String x:Key="ProPlusSPLA2021Volume">Office LTSC Professional Plus 2021 (SPLA) - 볼륨 라이선스</sys:String>
     <sys:String x:Key="ProPlus2024Volume">Office LTSC Professional Plus 2024 - 볼륨 라이선스</sys:String>
     <sys:String x:Key="ProPlusRetail">Office Professional Plus 2016</sys:String>


### PR DESCRIPTION
The version inquiry and product list do not display Office LTSC Professional Plus 2024 - Volume License information.